### PR TITLE
chore(react): migrate to stream-chat-react v14

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -8,19 +8,19 @@
 			"name": "react-chat-ai-tutorial",
 			"version": "0.0.0",
 			"dependencies": {
-				"@stream-io/chat-react-ai": "^0.1.2",
+				"@stream-io/chat-react-ai": "^0.2.0",
 				"clsx": "^2.1.1",
 				"material-symbols": "^0.40.0",
 				"nanoid": "^5.1.6",
-				"react": "^19.2.0",
-				"react-dom": "^19.2.0",
-				"stream-chat": "^9.26.1",
-				"stream-chat-react": "^13.13.0"
+				"react": "^19.2.5",
+				"react-dom": "^19.2.5",
+				"stream-chat": "^9.41.0",
+				"stream-chat-react": "^14.0.1"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.39.1",
 				"@types/node": "^24.10.1",
-				"@types/react": "^19.2.5",
+				"@types/react": "^19.2.14",
 				"@types/react-dom": "^19.2.3",
 				"@vitejs/plugin-react": "^5.1.1",
 				"eslint": "^9.39.1",
@@ -1502,9 +1502,9 @@
 			]
 		},
 		"node_modules/@stream-io/chat-react-ai": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@stream-io/chat-react-ai/-/chat-react-ai-0.1.2.tgz",
-			"integrity": "sha512-g9WJb/TgNiX5vc9HSN8M80mDibaWuZkkZdaNulIJ6cI+5I6gLNPV4w+SzvFbClZcijGu3oZGkwoADzcKACPoeA==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@stream-io/chat-react-ai/-/chat-react-ai-0.2.0.tgz",
+			"integrity": "sha512-b740qw51KeV8YSyfAArHuv3ebxOhJr0yQGC3R7oqz4e7GbgovwfcWBxAN1gtc5fShy69JyZFm7IjD6AK69lyDg==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@stream-io/state-store": "^1.1.6",
@@ -1700,9 +1700,9 @@
 			}
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.7",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
-			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+			"version": "19.2.14",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -3745,12 +3745,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/lodash.defaultsdeep": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-			"integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
-			"license": "MIT"
-		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4774,6 +4768,18 @@
 				"node": "*"
 			}
 		},
+		"node_modules/modern-normalize": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-3.0.1.tgz",
+			"integrity": "sha512-VqlMdYi59Uch6fnUPxnpijWUQe+TW6zeWCvyr6Mb7JibheHzSuAAoJi2c71ZwIaWKpECpGpYHoaaBp6rBRr+/g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5054,9 +5060,9 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "19.2.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
-			"integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+			"integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5073,15 +5079,15 @@
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.2.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
-			"integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
+			"version": "19.2.5",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+			"integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
 			"license": "MIT",
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
 			"peerDependencies": {
-				"react": "^19.2.1"
+				"react": "^19.2.5"
 			}
 		},
 		"node_modules/react-dropzone": {
@@ -5530,9 +5536,9 @@
 			}
 		},
 		"node_modules/stream-chat": {
-			"version": "9.27.0",
-			"resolved": "https://registry.npmjs.org/stream-chat/-/stream-chat-9.27.0.tgz",
-			"integrity": "sha512-MG1Jo0eu1Z7W/wkytsGZlqvwh1YEACxAr/momrfd+g0rJA/wQ6vyC42edm91p47AVICL2c4IBK3CSVDGKOOoJQ==",
+			"version": "9.41.1",
+			"resolved": "https://registry.npmjs.org/stream-chat/-/stream-chat-9.41.1.tgz",
+			"integrity": "sha512-W8zjfINYol2UtdRMz2t/NN2GyjDrvb4pJgKmhtuRYzCY1u0Cjezcsu5OCNgyAM0QsenlY6tRqnvAU8Qam5R49Q==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@types/jsonwebtoken": "^9.0.8",
@@ -5550,9 +5556,9 @@
 			}
 		},
 		"node_modules/stream-chat-react": {
-			"version": "13.13.0",
-			"resolved": "https://registry.npmjs.org/stream-chat-react/-/stream-chat-react-13.13.0.tgz",
-			"integrity": "sha512-40FaoH/03TZlFxp3eAHPn9ZWFlwhW2bNdk26PPx/kFPd+a2VmU+IEUWG7h4IgjMQ22pfobAUVDX4swk6E3zagA==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/stream-chat-react/-/stream-chat-react-14.0.1.tgz",
+			"integrity": "sha512-lRC17STbJF7TzTqqBI2X3kFYsWsTT2Ynu72zD/g8w9mpGee1pGWnsmbu7Y+fenFYWy5K8cokGxrM6jvJdkxTSg==",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
@@ -5566,19 +5572,19 @@
 				"i18next": "^25.2.1",
 				"linkifyjs": "^4.3.2",
 				"lodash.debounce": "^4.0.8",
-				"lodash.defaultsdeep": "^4.6.1",
 				"lodash.mergewith": "^4.6.2",
 				"lodash.throttle": "^4.1.1",
 				"lodash.uniqby": "^4.7.0",
+				"modern-normalize": "^3.0.1",
 				"nanoid": "^3.3.4",
 				"react-dropzone": "^14.2.3",
 				"react-fast-compare": "^3.2.2",
-				"react-image-gallery": "1.2.12",
 				"react-markdown": "^9.0.3",
 				"react-player": "2.10.1",
 				"react-textarea-autosize": "^8.3.0",
 				"react-virtuoso": "^2.16.5",
 				"remark-gfm": "^4.0.1",
+				"ts-pattern": "^5.9.0",
 				"tslib": "^2.6.2",
 				"unist-builder": "^4.0.0",
 				"unist-util-visit": "^5.0.0",
@@ -5594,7 +5600,7 @@
 				"emoji-mart": "^5.4.0",
 				"react": "^19.0.0 || ^18.0.0 || ^17.0.0",
 				"react-dom": "^19.0.0 || ^18.0.0 || ^17.0.0",
-				"stream-chat": "^9.25.0"
+				"stream-chat": "^9.41.0"
 			},
 			"peerDependenciesMeta": {
 				"@breezystack/lamejs": {
@@ -5627,15 +5633,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
-		},
-		"node_modules/stream-chat-react/node_modules/react-image-gallery": {
-			"version": "1.2.12",
-			"resolved": "https://registry.npmjs.org/react-image-gallery/-/react-image-gallery-1.2.12.tgz",
-			"integrity": "sha512-JIh85lh0Av/yewseGJb/ycg00Y/weQiZEC/BQueC2Z5jnYILGB6mkxnrOevNhsM2NdZJpvcDekCluhy6uzEoTA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^16.0.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/stream-chat-react/node_modules/react-markdown": {
@@ -5778,6 +5775,12 @@
 			"peerDependencies": {
 				"typescript": ">=4.8.4"
 			}
+		},
+		"node_modules/ts-pattern": {
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+			"integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+			"license": "MIT"
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",

--- a/react/package.json
+++ b/react/package.json
@@ -10,19 +10,19 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"@stream-io/chat-react-ai": "^0.1.2",
+		"@stream-io/chat-react-ai": "^0.2.0",
 		"clsx": "^2.1.1",
 		"material-symbols": "^0.40.0",
 		"nanoid": "^5.1.6",
-		"react": "^19.2.0",
-		"react-dom": "^19.2.0",
-		"stream-chat": "^9.26.1",
-		"stream-chat-react": "^13.13.0"
+		"react": "^19.2.5",
+		"react-dom": "^19.2.5",
+		"stream-chat": "^9.41.0",
+		"stream-chat-react": "^14.0.1"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.39.1",
 		"@types/node": "^24.10.1",
-		"@types/react": "^19.2.5",
+		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^5.1.1",
 		"eslint": "^9.39.1",

--- a/react/src/components/ChannelListItem.css
+++ b/react/src/components/ChannelListItem.css
@@ -1,10 +1,11 @@
 .tut__channel-preview {
 	padding: 0.75rem 1rem;
 	cursor: pointer;
+	border-radius: var(--str-chat__radius-md);
 }
 
 .tut__channel-preview--active {
-	background-color: var(--str-chat__background-utility-selected);
+	background-color: var(--str-chat__background-utility-pressed);
 }
 
 .tut__channel-preview__text {

--- a/react/src/components/ChannelListItem.css
+++ b/react/src/components/ChannelListItem.css
@@ -4,11 +4,11 @@
 }
 
 .tut__channel-preview--active {
-	background-color: var(--str-chat__primary-surface-color);
+	background-color: var(--str-chat__background-utility-selected);
 }
 
 .tut__channel-preview__text {
 	font-size: 1rem;
 	font-weight: 500;
-	color: var(--str-chat__text-color);
+	color: var(--str-chat__text-primary);
 }

--- a/react/src/components/ChannelListItem.tsx
+++ b/react/src/components/ChannelListItem.tsx
@@ -1,8 +1,8 @@
-import type { ChannelPreviewProps } from "stream-chat-react";
+import type { ChannelListItemUIProps } from "stream-chat-react";
 import { useChatContext } from "stream-chat-react";
 import clsx from "clsx";
 
-export const ChannelListItem = (props: ChannelPreviewProps) => {
+export const ChannelListItem = (props: ChannelListItemUIProps) => {
 	const { id, data } = props.channel;
 	const { setActiveChannel, channel: activeChannel } = useChatContext();
 	const isActive = activeChannel?.id === id;

--- a/react/src/components/ChatContent.tsx
+++ b/react/src/components/ChatContent.tsx
@@ -3,7 +3,8 @@ import {
 	MessageList,
 	ChannelList,
 	Window,
-	MessageInput,
+	MessageComposer,
+	WithComponents,
 	useChatContext,
 	type ChannelListProps,
 } from "stream-chat-react";
@@ -34,21 +35,26 @@ export const ChatContent = ({
 	}, [channel]);
 
 	return (
-		<>
+		<WithComponents
+			overrides={{
+				ChannelListItemUI: ChannelListItem,
+				Message: MessageBubble,
+				MessageComposerUI: Composer,
+			}}
+		>
 			<ChannelList
-				Preview={ChannelListItem}
 				setActiveChannelOnMount={false}
 				filters={filters}
 				sort={sort}
 				options={options}
 			/>
-			<Channel initializeOnMount={false} Message={MessageBubble}>
+			<Channel initializeOnMount={false}>
 				<Window>
 					<MessageList />
 					<AIStateIndicator />
-					<MessageInput Input={Composer} />
+					<MessageComposer />
 				</Window>
 			</Channel>
-		</>
+		</WithComponents>
 	);
 };

--- a/react/src/components/Composer.tsx
+++ b/react/src/components/Composer.tsx
@@ -11,7 +11,7 @@ import {
 	useChannelActionContext,
 	useChannelStateContext,
 	useChatContext,
-	useMessageComposer,
+	useMessageComposerController,
 } from "stream-chat-react";
 import { startAiAgent, summarizeConversation } from "../api";
 
@@ -25,7 +25,7 @@ export const Composer = () => {
 	const { client } = useChatContext();
 	const { updateMessage, sendMessage } = useChannelActionContext();
 	const { channel } = useChannelStateContext();
-	const composer = useMessageComposer();
+	const composer = useMessageComposerController();
 
 	const { attachments } = useAttachmentsForPreview();
 

--- a/react/src/components/MessageBubble.tsx
+++ b/react/src/components/MessageBubble.tsx
@@ -1,9 +1,5 @@
 import { StreamingMessage } from "@stream-io/chat-react-ai";
-import {
-	Attachment,
-	MessageErrorIcon,
-	useMessageContext,
-} from "stream-chat-react";
+import { Attachment, useMessageContext } from "stream-chat-react";
 import clsx from "clsx";
 
 export const MessageBubble = () => {
@@ -38,7 +34,9 @@ export const MessageBubble = () => {
 						/>
 					)}
 					{message?.text && <StreamingMessage text={message.text} />}
-					<MessageErrorIcon />
+					{message?.status === "failed" && (
+						<div className="str-chat__message-error-indicator" />
+					)}
 				</div>
 			</div>
 		</div>

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -1,7 +1,7 @@
 @layer stream, stream-overrides, stream-ai;
 
 @import "material-symbols/rounded.css";
-@import url("stream-chat-react/dist/css/v2/index.css") layer(stream);
+@import url("stream-chat-react/css/index.css") layer(stream);
 @import url("@stream-io/chat-react-ai/styles/index.css") layer(stream-ai);
 
 @import url("./components/Composer.css");
@@ -46,7 +46,7 @@ body {
 		width: 100%;
 	}
 
-	.str-chat__list {
+	.str-chat__virtual-list {
 		display: flex;
 		justify-content: center;
 		scrollbar-gutter: stable;

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -1,4 +1,4 @@
-@layer stream, stream-overrides, stream-ai;
+@layer stream, stream-overrides, stream-ai, stream-ai-overrides;
 
 @import "material-symbols/rounded.css";
 @import url("stream-chat-react/css/index.css") layer(stream);
@@ -55,9 +55,16 @@ body {
 
 	.str-chat__message--other .str-chat__message-bubble {
 		max-width: unset;
+		width: 100%;
 	}
 
 	.str-chat__message--other .str-chat__message-inner {
 		margin-inline-end: 0;
+	}
+}
+
+@layer stream-ai-overrides {
+	.aicr__pre {
+		white-space: break-spaces;
 	}
 }


### PR DESCRIPTION
## Summary
- Upgrades the Vite `react/` tutorial from `stream-chat-react@^13.13.0` to `^14.0.1` and `stream-chat` to `^9.41.0` (v14 peer requirement).
- Migrates off removed/renamed v13 APIs: `MessageInput` → `MessageComposer`, `Preview`/`Message` direct overrides → `<WithComponents overrides={{ ChannelListItemUI, Message, MessageComposerUI }}>`, `useMessageComposer()` → `useMessageComposerController()`, `ChannelPreviewProps` → `ChannelListItemUIProps`, removed `MessageErrorIcon` replaced with an inline `.str-chat__message-error-indicator` on failed messages.
- CSS: updates the stylesheet entry path and renames `.str-chat__list` → `.str-chat__virtual-list`; swaps removed v13 CSS vars in `ChannelListItem.css` (`--str-chat__primary-surface-color` → `--str-chat__background-utility-selected`; `--str-chat__text-color` → `--str-chat__text-primary`).
- Also bumps `@stream-io/chat-react-ai` to `^0.2.0` and pins `react`/`react-dom` to `^19.2.5` so peers resolve cleanly under strict npm.

## Test plan
- [x] \`npx tsc -b --noEmit\` — clean
- [x] \`npm run build\` — Vite production build succeeds
- [ ] Browser smoke test: channel list renders with custom \`ChannelListItem\`, selecting a channel loads the message list, empty channel auto-creates, text send + file upload work, model select dispatches, \`AIStateIndicator\` appears during generation, streaming message text renders, channel \`summary\` updates, failed-message error indicator renders, no console errors