### PR TITLE
migrate(ios): StreamChatSwiftUI v4.99.1 → v5.1.0

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -4,6 +4,9 @@
 # Environment Variables
 .env
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore

--- a/ios/AIComponents.xcodeproj/project.pbxproj
+++ b/ios/AIComponents.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift-ai.git";
 			requirement = {
-				branch = "chore/swift-sdk-0.12.0";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/ios/AIComponents.xcodeproj/project.pbxproj
+++ b/ios/AIComponents.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		84144E042EB8E95D00D0D034 /* MCP in Frameworks */ = {isa = PBXBuildFile; productRef = 84144E032EB8E95D00D0D034 /* MCP */; };
 		8464FB542EABCB5B00933768 /* StreamChatSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 8464FB532EABCB5B00933768 /* StreamChatSwiftUI */; };
-		8464FB582EABCBC200933768 /* StreamChatAI in Frameworks */ = {isa = PBXBuildFile; productRef = 8464FB572EABCBC200933768 /* StreamChatAI */; };
 		84F35D3E2EDA5E6A0014D30F /* StreamChatAI in Frameworks */ = {isa = PBXBuildFile; productRef = 84F35D3D2EDA5E6A0014D30F /* StreamChatAI */; };
 /* End PBXBuildFile section */
 
@@ -31,7 +30,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				84144E042EB8E95D00D0D034 /* MCP in Frameworks */,
-				8464FB582EABCBC200933768 /* StreamChatAI in Frameworks */,
 				84F35D3E2EDA5E6A0014D30F /* StreamChatAI in Frameworks */,
 				8464FB542EABCB5B00933768 /* StreamChatSwiftUI in Frameworks */,
 			);
@@ -85,7 +83,6 @@
 			name = AIComponents;
 			packageProductDependencies = (
 				8464FB532EABCB5B00933768 /* StreamChatSwiftUI */,
-				8464FB572EABCBC200933768 /* StreamChatAI */,
 				84144E032EB8E95D00D0D034 /* MCP */,
 				84F35D3D2EDA5E6A0014D30F /* StreamChatAI */,
 			);
@@ -383,14 +380,14 @@
 			repositoryURL = "https://github.com/GetStream/stream-chat-swiftui";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.93.0;
+				minimumVersion = 5.0.0;
 			};
 		};
 		84F35D3C2EDA5E6A0014D30F /* XCRemoteSwiftPackageReference "stream-chat-swift-ai" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-chat-swift-ai.git";
 			requirement = {
-				branch = main;
+				branch = "chore/swift-sdk-0.12.0";
 				kind = branch;
 			};
 		};
@@ -406,10 +403,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8464FB522EABCB5B00933768 /* XCRemoteSwiftPackageReference "stream-chat-swiftui" */;
 			productName = StreamChatSwiftUI;
-		};
-		8464FB572EABCBC200933768 /* StreamChatAI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = StreamChatAI;
 		};
 		84F35D3D2EDA5E6A0014D30F /* StreamChatAI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios/AIComponents/AIComponentsApp.swift
+++ b/ios/AIComponents/AIComponentsApp.swift
@@ -25,11 +25,12 @@ struct AIComponentsApp: App {
     
     init() {
         let messageListConfig = MessageListConfig(messageDisplayOptions: .init(
-            showAvatars: false,
+            showIncomingMessageAvatar: false,
+            showOutgoingMessageAvatar: false,
             showAvatarsInGroups: false,
             showMessageDate: false,
             showAuthorName: false,
-            spacerWidth: { _ in return 16 },
+            spacerWidth: { _ in return 16 }
         ), skipEditedMessageLabel: { message in
             message.extraData["ai_generated"]?.boolValue == true
         })

--- a/ios/AIComponents/AIComponentsFactory.swift
+++ b/ios/AIComponents/AIComponentsFactory.swift
@@ -56,7 +56,7 @@ class AIComponentsViewFactory: ViewFactory {
 
 final class AIComponentsStyles: Styles {
     var composerPlacement: ComposerPlacement = .docked
-    var typingIndicatorHandler: TypingIndicatorHandler?
+    var typingIndicatorHandler: TypingIndicatorHandler!
 
     func makeMessageListContainerModifier(
         options: MessageListContainerModifierOptions

--- a/ios/AIComponents/AIComponentsFactory.swift
+++ b/ios/AIComponents/AIComponentsFactory.swift
@@ -11,34 +11,34 @@ import StreamChatAI
 import StreamChatSwiftUI
 
 class AIComponentsViewFactory: ViewFactory {
-    
+
     @Injected(\.chatClient) var chatClient: ChatClient
-    
+
     private let actionHandler = ClientToolActionHandler.shared
     var typingIndicatorHandler: TypingIndicatorHandler!
-    
+    var styles = AIComponentsStyles()
+
     private init() {}
-    
+
     static let shared = AIComponentsViewFactory()
-        
+
     public func makeMessageListBackground(
-        colors: ColorPalette,
-        isInThread: Bool
+        options: MessageListBackgroundOptions
     ) -> some View {
         Color.clear
     }
-    
-    func makeMessageReadIndicatorView(channel: ChatChannel, message: ChatMessage) -> some View {
+
+    func makeMessageReadIndicatorView(
+        options: MessageReadIndicatorViewOptions
+    ) -> some View {
         EmptyView()
     }
-    
+
     @ViewBuilder
     func makeCustomAttachmentViewType(
-        for message: ChatMessage,
-        isFirst: Bool,
-        availableWidth: CGFloat,
-        scrolledId: Binding<String?>
+        options: CustomAttachmentViewTypeOptions
     ) -> some View {
+        let message = options.message
         let isGenerating = message.extraData["generating"]?.boolValue == true
         StreamingMessageView(
             content: message.text,
@@ -46,15 +46,33 @@ class AIComponentsViewFactory: ViewFactory {
         )
         .padding()
     }
-    
-    func makeMessageListContainerModifier() -> some ViewModifier {
-        CustomMessageListContainerModifier(typingIndicatorHandler: typingIndicatorHandler)
-    }
-    
+
     func makeEmptyMessagesView(
-        for channel: ChatChannel,
-        colors: ColorPalette
+        options: EmptyMessagesViewOptions
     ) -> some View {
         AIAgentOverlayView(typingIndicatorHandler: typingIndicatorHandler)
+    }
+}
+
+final class AIComponentsStyles: Styles {
+    var composerPlacement: ComposerPlacement = .docked
+    var typingIndicatorHandler: TypingIndicatorHandler?
+
+    func makeMessageListContainerModifier(
+        options: MessageListContainerModifierOptions
+    ) -> some ViewModifier {
+        CustomMessageListContainerModifier(typingIndicatorHandler: typingIndicatorHandler)
+    }
+
+    func makeComposerInputViewModifier(options: ComposerInputModifierOptions) -> some ViewModifier {
+        RegularInputViewModifier()
+    }
+
+    func makeComposerButtonViewModifier(options: ComposerButtonModifierOptions) -> some ViewModifier {
+        RegularButtonViewModifier()
+    }
+
+    func makeSuggestionsContainerModifier(options: SuggestionsContainerModifierOptions) -> some ViewModifier {
+        SuggestionsRegularContainerModifier()
     }
 }

--- a/ios/AIComponents/ContentView.swift
+++ b/ios/AIComponents/ContentView.swift
@@ -61,7 +61,9 @@ struct ContentView: View {
             )
         }
         .onAppear {
-            AIComponentsViewFactory.shared.typingIndicatorHandler = _typingIndicatorHandler.wrappedValue
+            let handler = _typingIndicatorHandler.wrappedValue
+            AIComponentsViewFactory.shared.typingIndicatorHandler = handler
+            AIComponentsViewFactory.shared.styles.typingIndicatorHandler = handler
             viewModel.chatOptions = createChatOptions()
         }
     }
@@ -355,12 +357,13 @@ private struct ComposerHeightPreferenceKey: PreferenceKey {
 }
 
 struct CustomMessageListContainerModifier: ViewModifier {
-    
-    @ObservedObject var typingIndicatorHandler: TypingIndicatorHandler
-    
+    let typingIndicatorHandler: TypingIndicatorHandler?
+
     func body(content: Content) -> some View {
         content.overlay {
-            AIAgentOverlayView(typingIndicatorHandler: typingIndicatorHandler)
+            if let typingIndicatorHandler {
+                AIAgentOverlayView(typingIndicatorHandler: typingIndicatorHandler)
+            }
         }
     }
 }

--- a/ios/AIComponents/ContentView.swift
+++ b/ios/AIComponents/ContentView.swift
@@ -357,13 +357,11 @@ private struct ComposerHeightPreferenceKey: PreferenceKey {
 }
 
 struct CustomMessageListContainerModifier: ViewModifier {
-    let typingIndicatorHandler: TypingIndicatorHandler?
+    @ObservedObject var typingIndicatorHandler: TypingIndicatorHandler
 
     func body(content: Content) -> some View {
         content.overlay {
-            if let typingIndicatorHandler {
-                AIAgentOverlayView(typingIndicatorHandler: typingIndicatorHandler)
-            }
+            AIAgentOverlayView(typingIndicatorHandler: typingIndicatorHandler)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Bump StreamChatSwiftUI SPM constraint `4.93.0` → `5.0.0` (resolves to **5.1.0**) and adapt the `AIComponents` sample to the v5 `ViewFactory` / `Styles` split.
- Pre-existing data race in `swift-sdk@0.10.2` (transitively pinned by `stream-chat-swift-ai`) blocked the build under Xcode 26+. This PR temporarily points `stream-chat-swift-ai` at the `chore/swift-sdk-0.12.0` branch via SPM `branch =`. Once GetStream/stream-chat-swift-ai#3 lands and a release is cut, switch this back to `main` (or pin a tag).
- Verified: `xcodebuild -scheme AIComponents -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' build` succeeds.

## What changed

**`AIComponents/AIComponentsFactory.swift`** — full v5 rewrite:
- 4 `ViewFactory` overrides moved to options-bag signatures: `makeMessageListBackground`, `makeMessageReadIndicatorView`, `makeCustomAttachmentViewType`, `makeEmptyMessagesView`.
- New `final class AIComponentsStyles: Styles` holds `makeMessageListContainerModifier(options:)` (which moved off `ViewFactory` in v5).
- `RegularStyles` is `public class` (not `open`), so subclassing it cross-module is not possible. `AIComponentsStyles` conforms to `Styles` directly and implements the 3 required-no-default methods using the public `RegularInputViewModifier`, `RegularButtonViewModifier`, `SuggestionsRegularContainerModifier` types to preserve the default appearance.
- Added `var styles = AIComponentsStyles()` to satisfy the v5 `ViewFactory.styles` requirement.

**`AIComponents/AIComponentsApp.swift`** — `MessageDisplayOptions` v5 update:
- `showAvatars: false` split into `showIncomingMessageAvatar: false`, `showOutgoingMessageAvatar: false`.

**`AIComponents/ContentView.swift`**:
- `.onAppear` now wires the typing-indicator handler to both `factory.typingIndicatorHandler` and `factory.styles.typingIndicatorHandler`.
- `CustomMessageListContainerModifier.typingIndicatorHandler` is now `let TypingIndicatorHandler?` with an `if let` inside `body`, so `AIComponentsStyles.makeMessageListContainerModifier` can return a single concrete `ViewModifier` type.

**`AIComponents.xcodeproj/project.pbxproj`**:
- Bump `stream-chat-swiftui` SPM constraint to `5.0.0` (`upToNextMajorVersion`).
- Point `stream-chat-swift-ai` SPM ref at `branch = chore/swift-sdk-0.12.0`.
- Removed the local-package reference and orphan `StreamChatAI` build/dep entries that had been added for local testing.

**`ios/.gitignore`** — adds `.claude/settings.local.json` (personal Claude Code overrides).

## Test plan

- [x] `xcodebuild build` on iPhone 17 Pro / iOS 26.2 — `BUILD SUCCEEDED`
- [ ] Manual smoke test on simulator (10 items mapping each ViewFactory override to a visible behaviour — the v5 migration guide warns that stale v4 method signatures *compile* but silently fall back to defaults, so behavioural verification is mandatory):
  - App launches, channel list / sidebar appears
  - Send a suggestion → channel created, AI responds
  - Streaming view animates the assistant response (validates `makeCustomAttachmentViewType`)
  - "Thinking" / "Checking external sources" indicator appears as a 60pt bar at the bottom of the message list (validates `AIComponentsStyles.makeMessageListContainerModifier`)
  - Empty channel state shows `AIAgentOverlayView` (validates `makeEmptyMessagesView`)
  - Read indicators absent on assistant messages (validates `makeMessageReadIndicatorView`)
  - Message list background transparent (validates `makeMessageListBackground`)
  - Open existing conversation from sidebar
  - Send follow-up message; streaming + indicator re-engage
  - "Stop generating" mid-stream clears the indicator
- [ ] After GetStream/stream-chat-swift-ai#3 merges + a release is tagged: revert the `branch = chore/swift-sdk-0.12.0` line back to `main` (or pin to the new tag).

## Related

- Depends on: GetStream/stream-chat-swift-ai#3 (`chore: bump swift-sdk to 0.12.0 to fix NetworkTransport data race`)
- Docs: GetStream/docs-content PR (link to follow) — fixes 3 v5 doc examples that still subclass `RegularStyles`, and adds the missing `MessageDisplayOptions.showAvatars` migration section.

## Linear

[IOS-1656 — Update AI Components sample app and docs to 5.0](https://linear.app/stream/issue/IOS-1656/update-ai-components-sample-app-and-docs-to-50)